### PR TITLE
update services graph

### DIFF
--- a/metric.js
+++ b/metric.js
@@ -39,7 +39,7 @@ function massage(data,config,provider){
 
 //Sent data to Segment
 function sentData(data){
-  var id = 'unknown';
+  var id = 'unknownID';
   if(data.cfMetric.space_id) id = data.cfMetric.space_id;
   analytics.track({
     userId: id,


### PR DESCRIPTION
Since there are too many services in the services graph, I keep the top 9 services in the graph and combine the rest of the service counts as `others`.