### PR TITLE
Use Redis to Cache stats page

### DIFF
--- a/app.js
+++ b/app.js
@@ -391,7 +391,7 @@ app.get("/company/:hash/:service", [forceSslIfNotLocal, authenticate()], functio
           });
           res.render("company_service", {dataU: JSON.stringify(usagePerUnit),
                                 dataRaw: perUnit, service: serviceTitle,
-                                company: companyTitle});
+                                company: companyTitle, companyHash: hash});
         }catch(ex){
         }
       }
@@ -402,6 +402,7 @@ app.get("/company/:hash", [forceSslIfNotLocal, authenticate()], function(req, re
     var app = req.app;
     var hash = req.params.hash;
     var companyTitle = '';
+    var companyHash = '';
     var deploymentTrackerDb = app.get("deployment-tracker-db");
     var eventsDb = deploymentTrackerDb.use("usagedata");
     var cloudfoundry = [];
@@ -423,7 +424,7 @@ app.get("/company/:hash", [forceSslIfNotLocal, authenticate()], function(req, re
               if(usage != null){
               usage.forEach(function(service){
                 service["key2"] = service.key.replace(/\s+/g, '');
-                service["company"] = companyTitle;
+                service["company"] = companyTitle.replace(/\s+/g, '');
                 });
               }else{
                 usage = [];

--- a/views/bluemix.html
+++ b/views/bluemix.html
@@ -88,7 +88,7 @@
      document.getElementById("service_button").addEventListener("click", function () {
         document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
                                                       "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
-                                                      "Estimated API calls from IBM Code users. " +
+                                                      "API calls from all IBM Cloud users. " +
                                                       "<div id=\"datavischart\"></div> " +
                                                       "<p style=\"font-size: 10px\"> Note: 1G = 1 Billion</p>" + 
                                                       "</figure>";
@@ -100,7 +100,7 @@
      document.getElementById("cf_button").addEventListener("click", function () {
         document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
                                                       "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
-                                                      "Estimated Cloud Foundry usage (GB per hour) from IBM Code users. <br> " +
+                                                      "Cloud Foundry usage (GB per hour) all IBM Cloud users. <br> " +
                                                       "(Python, Go, PHP, Ruby, and Tomcat are Community Buildpacks)" +
                                                       "<div id=\"cfvischart\"></div> " +
                                                       "<p style=\"font-size: 10px\"> Note: 1G = 1 Billion</p>" + 
@@ -113,7 +113,7 @@
      document.getElementById("k8s_button").addEventListener("click", function () {
         document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
                                                       "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
-                                                      "Estimated Kubernetes usage (Instance hours) from IBM Code users. " +
+                                                      "Kubernetes usage (Instance hours) from all IBM Cloud users. " +
                                                       "<div id=\"k8vischart\"></div> " +
                                                       "</figure>";
        SimpleDataVis(kubernetes)

--- a/views/chatbot.html
+++ b/views/chatbot.html
@@ -45,11 +45,11 @@
               <div id="datavisdeploy"></div>
       </figure>
      </div>
-     <div class="col-xs-12 col-md-12 col-lg-12">
+<!--      <div class="col-xs-12 col-md-12 col-lg-12">
       <p style="text-align:center;">
      <a class="btn btn-primary btn-lg" href="/chatbotjson" role="button">Bot Asset Exchange Deployment Statistics in JSON</a>
    </p>
-   </div>
+   </div> -->
     <script src="/assets/jquery/dist/jquery.min.js"></script>
     <script src="/assets/bootstrap/dist/js/bootstrap.min.js"></script>
     <script src="/assets/zeroclipboard/dist/ZeroClipboard.min.js"></script>

--- a/views/company.html
+++ b/views/company.html
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>IBM Code Metrics Platform</title>
+    <link rel="stylesheet" type="text/css" href="/css/demo.css">
     <link rel="stylesheet" href="/assets/bootstrap/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="/assets/bootstrap/dist/css/bootstrap-theme.min.css">
-    <link rel="stylesheet" type="text/css" href="/css/demo.css">
     <script src="https://d3js.org/d3.v4.min.js"></script>
     <script src="/js/simpledatavis.js"></script>
     <script type="text/javascript" src="/js/vis/simpledatavis-barchart.js"></script>
@@ -34,14 +34,12 @@
     <article>         
       <ol class="breadcrumb">
           <li><a href="/stats">Stats</a></li>
-          <li><a href="/graphs">Graphs</a></li>
-          <li class="active">IBM Cloud (IBM Cloud Statistics)</li>
+          <li class="active">Company Statistics</li>
         </ol>
     </article>
       </div>
     </div>
-    </div>
-    <p style="text-align:center;">
+    <p style="text-align:center;" id="graph_button">
     <button class="btn btn-success btn-lg" id="service_button">Service Usage Graph</button>
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     <button class="btn btn-info btn-lg" id="cf_button">Cloud Foundry Usage Graph</button>
@@ -51,12 +49,26 @@
     <div class="col-xs-12 col-md-12 col-lg-12" id="graph">
     <figure class="guide-example theme_light bg_light-tint">
         <p class="type_mark" style="font-size: 30px">
-          API calls from all IBM Cloud users. 
-        </p>
-        <div id="datatotalvischart"></div>
-        <p style="font-size: 10px"> Note: 1G = 1 Billion</p>
+          {{company}}'s Estimated Service Usage. 
+        <div id="datavischart"></div>
     </figure>
    </div>
+  <div class="col-xs-12 col-md-12 col-lg-12">
+    <h2>&nbsp;&nbsp;&nbsp;&nbsp;Usage from {{company}} for Each Service
+<!--   <button type="button" class="btn btn-info" data-target="#expand" id ="more"> <span class="glyphicon glyphicon-collapse-down" aria-expanded="false"></span></button> -->
+   </h2>
+  </div>
+  <div id="expand" class="collapse in">
+    {{#each dataRaw}}
+    <div class="col-xs-6 col-md-6 col-lg-6">
+      <figure class="guide-example theme_light bg_light-tint">
+             <p class="type_mark" style="font-size: 25px; color: gray; font-weight: bold;"><a href="/company/{{company}}/{{key2}}">
+              {{key}}
+            </a><span class="badge">{{value}}</span></p>
+      </figure>
+    </div>
+    {{/each}}
+  </div>
     <script src="/assets/jquery/dist/jquery.min.js"></script>
     <script src="/assets/bootstrap/dist/js/bootstrap.min.js"></script>
     <script src="/assets/zeroclipboard/dist/ZeroClipboard.min.js"></script>
@@ -75,24 +87,23 @@
       return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
     }
     //graphs
-     var dataTotal = JSON.parse(htmlDecode("{{dataTotal}}"));
-     var cfBluemix = JSON.parse(htmlDecode("{{cfBluemix}}"));
-     var kubernetes = JSON.parse(htmlDecode("{{kubernetesBluemix}}"));
+     var dataW = JSON.parse(htmlDecode("{{dataW}}"));
+     var cloudfoundry = JSON.parse(htmlDecode("{{cloudfoundry}}"));
+     var kubernetes = JSON.parse(htmlDecode("{{kubernetes}}"));
      window.addEventListener('DOMContentLoaded', function () {
-       // All Bluemix usage
-       SimpleDataVis(dataTotal)
+      // Journey user usage
+       SimpleDataVis(dataW)
          .attr('type', 'stacked-bar-chart')
-         .render('#datatotalvischart')
+         .render('#datavischart')
      })
      // Journey user usage
      document.getElementById("service_button").addEventListener("click", function () {
         document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
                                                       "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
-                                                      "Estimated API calls from IBM Code users. " +
+                                                      "{{company}}'s Estimated Service Usage. " +
                                                       "<div id=\"datavischart\"></div> " +
-                                                      "<p style=\"font-size: 10px\"> Note: 1G = 1 Billion</p>" + 
                                                       "</figure>";
-        SimpleDataVis(dataTotal)
+        SimpleDataVis(dataW)
          .attr('type', 'stacked-bar-chart')
          .render('#datavischart')
      });
@@ -100,20 +111,20 @@
      document.getElementById("cf_button").addEventListener("click", function () {
         document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
                                                       "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
-                                                      "Estimated Cloud Foundry usage (GB per hour) from IBM Code users. <br> " +
+                                                      "Estimated Cloud Foundry usage (GB per hour) from {{company}}. <br> " +
                                                       "(Python, Go, PHP, Ruby, and Tomcat are Community Buildpacks)" +
                                                       "<div id=\"cfvischart\"></div> " +
-                                                      "<p style=\"font-size: 10px\"> Note: 1G = 1 Billion</p>" + 
                                                       "</figure>";
-       SimpleDataVis(cfBluemix)
+       SimpleDataVis(cloudfoundry)
          .attr('type', 'stacked-bar-chart')
          .render('#cfvischart')
+
      });
      //  Kubernetes Runtime
      document.getElementById("k8s_button").addEventListener("click", function () {
         document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
                                                       "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
-                                                      "Estimated Kubernetes usage (Instance hours) from IBM Code users. " +
+                                                      "Estimated Kubernetes usage (Instance hours) from {{company}}. " +
                                                       "<div id=\"k8vischart\"></div> " +
                                                       "</figure>";
        SimpleDataVis(kubernetes)

--- a/views/company.html
+++ b/views/company.html
@@ -122,6 +122,12 @@
      });
      //  Kubernetes Runtime
      document.getElementById("k8s_button").addEventListener("click", function () {
+      if(kubernetes.length < 1){
+        document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
+                                                      "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
+                                                      "Kubernetes usage from {{company}} is not available. " +
+                                                      "</figure>";
+      }else{
         document.getElementById("graph").innerHTML = "<figure class=\"guide-example theme_light bg_light-tint\"> " +
                                                       "<p class=\"type_mark\" style=\"font-size: 30px\"> " +
                                                       "Estimated Kubernetes usage (Instance hours) from {{company}}. " +
@@ -130,6 +136,7 @@
        SimpleDataVis(kubernetes)
          .attr('type', 'stacked-bar-chart')
          .render('#k8vischart')
+       }
      });
     $('#service_button').click(function () {
       if($('#service_button').hasClass('btn-success')){

--- a/views/company_service.html
+++ b/views/company_service.html
@@ -34,7 +34,7 @@
     <article>
       <ol class="breadcrumb">
           <li><a href="/stats">Stats</a></li>
-          <li><a href="/company/{{company}}">Company</a></li>
+          <li><a href="/company/{{companyHash}}">Company</a></li>
           <li class="active">Company Service Statistics</li>
         </ol>
     </article>

--- a/views/company_service.html
+++ b/views/company_service.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>IBM Code Metrics Platform</title>
+    <link rel="stylesheet" href="/assets/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/bootstrap/dist/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/demo.css">
+    <script src="https://d3js.org/d3.v4.min.js"></script>
+    <script src="/js/simpledatavis.js"></script>
+    <script type="text/javascript" src="/js/vis/simpledatavis-barchart.js"></script>
+    <script type="text/javascript" src="/js/vis/simpledatavis-piechart.js"></script>
+    <script type="text/javascript" src="/js/vis/simpledatavis-timeline.js"></script>
+    <script type="text/javascript" src="/js/vis/simpledatavis-stackedbarchart.js"></script>
+    <script type="text/javascript" src="/js/vis/simpledatavis-groupedbarchart.js"></script>
+    <style>
+      .copy {
+        cursor: pointer;
+      }
+    </style>
+    <!--[if lt IE 9]>
+      <script src="/assets/html5shiv/dist/html5shiv.min.js"></script>
+      <script src="/assets/respond/dest/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="jumbotron">
+      <div class="container">
+        <h1>IBM Code Metrics Platform</h1>
+        <p>Deployment and usage metrics for applications and workloads on CloudFoundry, Kubernetes, OpenWhisk etc.</p>
+<!--         <p><a class="btn btn-primary btn-lg" href="https://github.com/IBM-Bluemix/cf-deployment-tracker-service" target="_blank" role="button">View the source code on GitHub <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a></p> -->
+    <article>
+      <ol class="breadcrumb">
+          <li><a href="/stats">Stats</a></li>
+          <li><a href="/company/{{company}}">Company</a></li>
+          <li class="active">Company Service Statistics</li>
+        </ol>
+    </article>
+      </div>
+    </div>     
+    <figure class="guide-example theme_light bg_light-tint">
+        <p class="type_mark" style="font-size: 30px">
+          Estimated {{service}} usage by Unit from {{company}}.</p>
+    </figure>
+    {{#each dataRaw}}
+    <div class="col-xs-6 col-md-6 col-lg-6">
+      <figure class="guide-example theme_light bg_light-tint">
+          <p class="type_mark" style="font-size: 25px; color: gray; font-weight: bold;">
+            {{key}}</p>
+          <div id="{{key}}"></div>
+      </figure>
+    </div>
+    {{/each}}
+    <script src="/assets/jquery/dist/jquery.min.js"></script>
+    <script src="/assets/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script src="/assets/zeroclipboard/dist/ZeroClipboard.min.js"></script>
+    <script type="text/javascript">
+      $(document).ready(function() {
+        var client = new ZeroClipboard($(".copy span"));
+        client.on('aftercopy', function (event) {
+          $(event.target.parentNode).attr("title", "Copied!").tooltip("fixTitle").tooltip("show");
+        });
+        $("[data-toggle='tooltip']").tooltip();
+      });
+
+    function htmlDecode(input){
+      var e = document.createElement('div');
+      e.innerHTML = input;
+      return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+    }
+    //graphs
+     var dataU = JSON.parse(htmlDecode("{{dataU}}"));
+     Object.keys(dataU).map(function(key){
+        window.addEventListener('DOMContentLoaded', function () {
+         SimpleDataVis(dataU[key])
+           .attr('type', 'grouped-bar-chart')
+           .attr('tooltip', function (d) {
+           return d.key + ': ' + d.value 
+            })
+           .render('#' + key)
+       })
+     });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
The stats page is doing heavy redundant work, so I decided to use Redis to Cache the deployment data for every 15 minutes.
- Use Redis to Cache stats page, so we can reduce query workload from the cloudant data and reduce failure. 
- Since we only have 30MB limited for our Redis caching, we will not use it to cache other pages unless we expand our Redis service in the future. 